### PR TITLE
Fixed 2 bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,4 @@ FakesAssemblies/
 /packages
 
 *.userprefs
+.vs/

--- a/Emotes.cs
+++ b/Emotes.cs
@@ -16,6 +16,7 @@ namespace Emotes
         List<Emote> emotes = new List<Emote>();
         List<string> errors = new List<string>();
         Config config = new Config();
+        bool isEmotePlaying = false;
 
         MenuPool menuPool;
         UIMenu mainMenu;
@@ -24,19 +25,24 @@ namespace Emotes
         {
             // FiveM related things
             EventHandlers["onPlayerJoining"] += new Action<dynamic, dynamic>(OnPlayerJoining);
-            Tick += OnTick;
+            Tick += CancelEmoteTick;
+            Tick += MenuTick;
         }
 
-        public async Task OnTick()
+        async Task MenuTick()
+        {
+            await Delay(0);
+        }
+        async Task CancelEmoteTick()
         {
             //if (menuLoaded)
             menuPool.ProcessMenus();
 
             // Cancel emote when player is moving
-            if (Game.IsControlJustReleased(0, Control.MoveUpOnly) ||
+            if ((Game.IsControlJustReleased(0, Control.MoveUpOnly) ||
                 Game.IsControlJustReleased(0, Control.MoveDownOnly) ||
                 Game.IsControlJustReleased(0, Control.MoveLeftOnly) ||
-                Game.IsControlJustReleased(0, Control.MoveRightOnly))
+                Game.IsControlJustReleased(0, Control.MoveRightOnly)) && isEmotePlaying)
             {
                 CancelEmote();
             }
@@ -112,6 +118,7 @@ namespace Emotes
         void CancelEmote()
         {
             Function.Call(Hash.CLEAR_PED_TASKS, Game.PlayerPed);
+            isEmotePlaying = false;
         }
 
         void PlayEmote(Emote emote)
@@ -123,6 +130,7 @@ namespace Emotes
                 if (!isInVehicle)
                 {
                     Function.Call(Hash.TASK_START_SCENARIO_IN_PLACE, Game.PlayerPed, emote.EmoteType, emote.Delay, emote.PlayEnterAnim);
+                    isEmotePlaying = true;
                     Screen.ShowNotification(emote.Description);
                 }
                 else
@@ -157,8 +165,10 @@ namespace Emotes
 
             // Crée le menu
             menuPool = new MenuPool();
-            mainMenu = new UIMenu("Emotes", "Select an emote");
-            mainMenu.MouseControlsEnabled = false;
+            mainMenu = new UIMenu("Emotes", "Select an emote")
+            {
+                MouseControlsEnabled = false
+            };
             menuPool.Add(mainMenu);
             mainMenu.OnItemSelect += OnItemSelect;
 

--- a/Emotes.cs
+++ b/Emotes.cs
@@ -154,6 +154,9 @@ namespace Emotes
         // TODO: Should check if player already loaded
         void OnPlayerJoining(dynamic arg1, dynamic arg2)
         {
+            if (emotes.Count != 0)
+                return;
+
             // Récupère les configs et la liste d'emote
             LoadConfig();
             LoadJson();

--- a/Emotes.cs
+++ b/Emotes.cs
@@ -24,7 +24,10 @@ namespace Emotes
         public Emotes()
         {
             // FiveM related things
-            EventHandlers["onPlayerJoining"] += new Action<dynamic, dynamic>(OnPlayerJoining);
+            if (Game.IsLoading)
+                EventHandlers["onPlayerJoining"] += new Action<dynamic, dynamic>(OnPlayerJoining);
+            else
+                OnPlayerJoining(null, null);
             Tick += CancelEmoteTick;
         }
 

--- a/Emotes.cs
+++ b/Emotes.cs
@@ -26,13 +26,8 @@ namespace Emotes
             // FiveM related things
             EventHandlers["onPlayerJoining"] += new Action<dynamic, dynamic>(OnPlayerJoining);
             Tick += CancelEmoteTick;
-            Tick += MenuTick;
         }
 
-        async Task MenuTick()
-        {
-            await Delay(0);
-        }
         async Task CancelEmoteTick()
         {
             //if (menuLoaded)

--- a/Emotes.csproj
+++ b/Emotes.csproj
@@ -70,7 +70,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CitizenFX.Core">
-      <HintPath>..\..\..\FiveM\FiveM.app\citizen\clr2\lib\mono\4.5\CitizenFX.Core.dll</HintPath>
+      <HintPath>..\..\!FiveM Projects\!References\client\CitizenFX.Core.dll</HintPath>
     </Reference>
     <Reference Include="nativeui.net">
       <HintPath>.\nativeui.net.dll</HintPath>
@@ -91,7 +91,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /y "$(TargetPath)" "C:\Users\marceau\Desktop\Server\cfx-server\resources\emotes"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <ProjectExtensions />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
I fixed an issue where it kept trying to cancel the scenario even when it wasn't playing an emote. This cause weapon zooming, entering vehicles, and other player anims to either mess up or crash the game. 

I also fixed an issue where the emotes would duplicate on the menu, so if there was 5 emotes to be added, then 10 would show up. Seems to be an issue with FiveM like activating the onPlayerJoining event twice or something, so I just added a check for if the emote list is empty, and returned if it wasn't.

You're welcome.